### PR TITLE
テストを Meson でビルドできるようにする

### DIFF
--- a/gst-plugin/meson.build
+++ b/gst-plugin/meson.build
@@ -65,3 +65,5 @@ fbdevsink = library('gstacmfbdevsink',
                     dependencies : [video],
                     include_directories : inc,
                     link_with : v4l2)
+
+subdir('tests')

--- a/gst-plugin/tests/acmaacdec.c
+++ b/gst-plugin/tests/acmaacdec.c
@@ -220,7 +220,7 @@ test_decode_adts_chain(GstPad * pad, GstObject * parent, GstBuffer * buf)
 		fail_if (outbuffer == NULL);
 		fail_unless (GST_IS_BUFFER (outbuffer));
 		
-		sprintf(file, "data/aac/adts/pcm_%03d.data", nOutputBuffers);
+		sprintf(file, GST_TEST_FILES_PATH "data/aac/adts/pcm_%03d.data", nOutputBuffers);
 		g_print("%s\n", file);
 		get_data(file, &size, &p);
 		
@@ -269,7 +269,7 @@ GST_START_TEST (test_decode_adts)
 	while (TRUE) {
 		/* バッファの入力 */
 		if (++nInputBuffers < PUSH_BUFFERS) {
-			sprintf(file, "data/aac/adts/aac_%03d.data", nInputBuffers);
+			sprintf(file, GST_TEST_FILES_PATH "data/aac/adts/aac_%03d.data", nInputBuffers);
 			g_print("%s\n", file);
 			get_data(file, &size, &p);
 			inbuffer = gst_buffer_new_and_alloc (size);
@@ -325,7 +325,7 @@ test_decode_raw_chain(GstPad * pad, GstObject * parent, GstBuffer * buf)
 		fail_if (outbuffer == NULL);
 		fail_unless (GST_IS_BUFFER (outbuffer));
 		
-		sprintf(file, "data/aac/raw/pcm_%03d.data", nOutputBuffers);
+		sprintf(file, GST_TEST_FILES_PATH "data/aac/raw/pcm_%03d.data", nOutputBuffers);
 		g_print("%s\n", file);
 		get_data(file, &size, &p);
 		
@@ -358,7 +358,7 @@ GST_START_TEST (test_decode_raw)
 	GstBuffer *inbuffer;
 	gint nInputBuffers = 0;
 
-	sprintf(file, "data/aac/raw/_codec_data.data");
+	sprintf(file, GST_TEST_FILES_PATH "data/aac/raw/_codec_data.data");
 	g_print("%s\n", file);
 	get_data(file, &size, &p);
 	codec_buf = gst_buffer_new_and_alloc (size);
@@ -383,7 +383,7 @@ GST_START_TEST (test_decode_raw)
 	while (TRUE) {
 		/* バッファの入力 */
 		if (++nInputBuffers < PUSH_BUFFERS) {
-			sprintf(file, "data/aac/raw/aac_%03d.data", nInputBuffers);
+			sprintf(file, GST_TEST_FILES_PATH "data/aac/raw/aac_%03d.data", nInputBuffers);
 			g_print("%s\n", file);
 			get_data(file, &size, &p);
 			inbuffer = gst_buffer_new_and_alloc (size);

--- a/gst-plugin/tests/acmaacenc.c
+++ b/gst-plugin/tests/acmaacenc.c
@@ -828,7 +828,7 @@ GST_START_TEST (test_encode_prop01)
 	gst_pad_set_chain_function (mysinkpad,
 		GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 
-	strcpy(g_output_data_file_path, "data/aac_enc/propset01/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset01/aac_%03d.data");
 
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_1CH_CAPS_STRING);
@@ -864,7 +864,7 @@ GST_START_TEST (test_encode_prop02)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset02/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset02/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_1CH_CAPS_STRING);
@@ -901,7 +901,7 @@ GST_START_TEST (test_encode_prop03)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset03/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset03/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_1CH_CAPS_STRING);
@@ -938,7 +938,7 @@ GST_START_TEST (test_encode_prop11)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset11/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset11/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_2CH_CAPS_STRING);
@@ -974,7 +974,7 @@ GST_START_TEST (test_encode_prop12)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset12/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset12/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_2CH_CAPS_STRING);
@@ -1011,7 +1011,7 @@ GST_START_TEST (test_encode_prop13)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset13/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset13/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_2CH_CAPS_STRING);
@@ -1052,7 +1052,7 @@ GST_START_TEST (test_encode_prop21)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset21/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset21/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_2CH_CAPS_STRING);
@@ -1092,7 +1092,7 @@ GST_START_TEST (test_encode_prop22)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset22/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset22/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_2CH_CAPS_STRING);
@@ -1133,7 +1133,7 @@ GST_START_TEST (test_encode_prop23)
 	gst_pad_set_chain_function (mysinkpad,
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	
-	strcpy(g_output_data_file_path, "data/aac_enc/propset23/aac_%03d.data");
+	strcpy(g_output_data_file_path, GST_TEST_FILES_PATH "data/aac_enc/propset23/aac_%03d.data");
 	
 	/* set src caps */
 	srccaps = gst_caps_from_string (AUDIO_2CH_CAPS_STRING);

--- a/gst-plugin/tests/acmh264dec.c
+++ b/gst-plugin/tests/acmh264dec.c
@@ -214,7 +214,7 @@ test_decode_mp4_chain(GstPad * pad, GstObject * parent, GstBuffer * buf)
 		fail_if (outbuffer == NULL);
 		fail_unless (GST_IS_BUFFER (outbuffer));
 		
-		sprintf(file, "data/h264/mp4/rgb_%03d.data", nOutputBuffers);
+		sprintf(file, GST_TEST_FILES_PATH "data/h264/mp4/rgb_%03d.data", nOutputBuffers);
 		g_print("%s\n", file);
 
 		get_data(file, &size, &p);
@@ -248,7 +248,7 @@ GST_START_TEST (test_decode_mp4)
 	GstBuffer *inbuffer;
 	gint nInputBuffers = 0;
 
-	sprintf(file, "data/h264/mp4/_codec_data.data");
+	sprintf(file, GST_TEST_FILES_PATH "data/h264/mp4/_codec_data.data");
 	g_print("%s\n", file);
 	get_data(file, &size, &p);
 	codec_buf = gst_buffer_new_and_alloc (size);
@@ -272,7 +272,7 @@ GST_START_TEST (test_decode_mp4)
 	while (TRUE) {
 		/* バッファの入力 */
 		if (++nInputBuffers < PUSH_BUFFERS) {
-			sprintf(file, "data/h264/mp4/h264_%03d.data", nInputBuffers);
+			sprintf(file, GST_TEST_FILES_PATH "data/h264/mp4/h264_%03d.data", nInputBuffers);
 			g_print("%s\n", file);
 
 			get_data(file, &size, &p);
@@ -331,7 +331,7 @@ test_decode_ts_chain(GstPad * pad, GstObject * parent, GstBuffer * buf)
 		fail_if (outbuffer == NULL);
 		fail_unless (GST_IS_BUFFER (outbuffer));
 		
-		sprintf(file, "data/h264/ts/rgb_%03d.data", nOutputBuffers);
+		sprintf(file, GST_TEST_FILES_PATH "data/h264/ts/rgb_%03d.data", nOutputBuffers);
 		g_print("%s\n", file);
 		
 		get_data(file, &size, &p);
@@ -365,7 +365,7 @@ GST_START_TEST (test_decode_ts)
 	GstBuffer *inbuffer;
 	gint nInputBuffers = 0;
 	
-	sprintf(file, "data/h264/ts/_codec_data.data");
+	sprintf(file, GST_TEST_FILES_PATH "data/h264/ts/_codec_data.data");
 	g_print("%s\n", file);
 	get_data(file, &size, &p);
 	codec_buf = gst_buffer_new_and_alloc (size);
@@ -389,7 +389,7 @@ GST_START_TEST (test_decode_ts)
 	while (TRUE) {
 		/* バッファの入力 */
 		if (++nInputBuffers < PUSH_BUFFERS) {
-			sprintf(file, "data/h264/ts/h264_%03d.data", nInputBuffers);
+			sprintf(file, GST_TEST_FILES_PATH "data/h264/ts/h264_%03d.data", nInputBuffers);
 			g_print("%s\n", file);
 			
 			get_data(file, &size, &p);

--- a/gst-plugin/tests/acmh264enc.c
+++ b/gst-plugin/tests/acmh264enc.c
@@ -982,7 +982,7 @@ check_encode_avc(gint B_pic_mode, gint max_GOP_length, gint rate_control_mode)
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	g_nOutputBuffers = 0;
 	
-	sprintf(g_output_data_file_path, "data/h264_enc/avc_propset%02d%02d%02d/",
+	sprintf(g_output_data_file_path, GST_TEST_FILES_PATH "data/h264_enc/avc_propset%02d%02d%02d/",
 			B_pic_mode, max_GOP_length, rate_control_mode);
 	strcat(g_output_data_file_path, "h264_%03d.data");
 	
@@ -991,7 +991,7 @@ check_encode_avc(gint B_pic_mode, gint max_GOP_length, gint rate_control_mode)
 	gst_pad_set_caps (mysrcpad, srccaps);
 	
 	/* input buffers */
-	input_buffers(PUSH_BUFFERS, "data/h264_enc/input01/yuv_%03d.data");
+	input_buffers(PUSH_BUFFERS, GST_TEST_FILES_PATH "data/h264_enc/input01/yuv_%03d.data");
 	
 	/* cleanup */
 	cleanup_acmh264enc (acmh264enc);
@@ -1021,7 +1021,7 @@ check_encode_bs(gint B_pic_mode, gint max_GOP_length, gint rate_control_mode)
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	g_nOutputBuffers = 0;
 
-	sprintf(g_output_data_file_path, "data/h264_enc/bs_propset%02d%02d%02d/",
+	sprintf(g_output_data_file_path, "GST_TEST_FILES_PATH data/h264_enc/bs_propset%02d%02d%02d/",
 			B_pic_mode, max_GOP_length, rate_control_mode);
 	strcat(g_output_data_file_path, "h264_%03d.data");
 	
@@ -1030,7 +1030,7 @@ check_encode_bs(gint B_pic_mode, gint max_GOP_length, gint rate_control_mode)
 	gst_pad_set_caps (mysrcpad, srccaps);
 	
 	/* input buffers */
-	input_buffers(PUSH_BUFFERS, "data/h264_enc/input01/yuv_%03d.data");
+	input_buffers(PUSH_BUFFERS, GST_TEST_FILES_PATH "data/h264_enc/input01/yuv_%03d.data");
 	
 	/* cleanup */
 	cleanup_acmh264enc (acmh264enc);

--- a/gst-plugin/tests/acmjpegenc.c
+++ b/gst-plugin/tests/acmjpegenc.c
@@ -752,7 +752,7 @@ check_encode(gint srcfmt, gint quality)
 								GST_DEBUG_FUNCPTR (test_encode_sink_chain));
 	g_nOutputBuffers = 0;
 
-	sprintf(g_output_data_file_path, "data/jpeg_enc/propset%02d/", quality);
+	sprintf(g_output_data_file_path, GST_TEST_FILES_PATH "data/jpeg_enc/propset%02d/", quality);
 	strcat(g_output_data_file_path, "jpeg_%03d.data");
 
 	/* set src caps */
@@ -771,11 +771,11 @@ check_encode(gint srcfmt, gint quality)
 
 	/* input buffers */
 	if (FMT_NV12 == srcfmt) {
-		input_buffers(PUSH_BUFFERS, "data/jpeg_enc/input01/yuv420_%03d.data");
+		input_buffers(PUSH_BUFFERS, GST_TEST_FILES_PATH "data/jpeg_enc/input01/yuv420_%03d.data");
 	}
 #if SUPPORT_NV16
 	else if (FMT_NV16 == srcfmt) {
-		input_buffers(PUSH_BUFFERS, "data/jpeg_enc/input02/yuv422_%03d.data");
+		input_buffers(PUSH_BUFFERS, GST_TEST_FILES_PATH "data/jpeg_enc/input02/yuv422_%03d.data");
 	}
 #endif
 	else {

--- a/gst-plugin/tests/meson.build
+++ b/gst-plugin/tests/meson.build
@@ -1,0 +1,38 @@
+gstreamer = dependency('gstreamer-1.0', version : '>1.0')
+gstapp = dependency('gstreamer-app-1.0', version : '>1.0')
+gstcheck = dependency('gstreamer-check-1.0', version : '>1.0')
+
+inc = include_directories('./')
+
+aacdec_src = ['acmaacdec.c']
+aacenc_src = ['acmaacenc.c', 'utest_util.c']
+h264dec_src = ['acmh264dec.c']
+h264enc_src = ['acmh264enc.c', 'utest_util.c']
+jpegenc_src = ['acmjpegenc.c', 'utest_util.c']
+fbdevsink_src = ['acmfbdevsink.c']
+
+h264dec = executable('acmh264dec',
+                     h264dec_src,
+                     dependencies : [gstreamer, gstcheck])
+
+aacdec = executable('acmaacdec',
+                    aacdec_src,
+                    dependencies : [gstreamer, gstcheck])
+
+aacenc = executable('acmaacenc',
+                    aacenc_src,
+                    dependencies : [gstreamer, gstcheck, gstapp],
+                    include_directories : inc)
+
+h264enc = executable('acmh264enc',
+                     h264enc_src,
+                     dependencies : [gstreamer, gstcheck, gstapp])
+
+jpegenc = executable('acmjpegenc',
+                     jpegenc_src,
+                     dependencies : [gstreamer, gstcheck, gstapp],
+                     include_directories : inc)
+
+fbdevsink = executable('acmfbdevsink',
+                       fbdevsink_src,
+                       dependencies : [gstreamer, gstcheck])

--- a/gst-plugin/tests/meson.build
+++ b/gst-plugin/tests/meson.build
@@ -11,28 +11,38 @@ h264enc_src = ['acmh264enc.c', 'utest_util.c']
 jpegenc_src = ['acmjpegenc.c', 'utest_util.c']
 fbdevsink_src = ['acmfbdevsink.c']
 
+test_defines = [
+  '-DGST_TEST_FILES_PATH="' + meson.current_source_dir() + '/"',
+ ]
+
 h264dec = executable('acmh264dec',
                      h264dec_src,
+                     c_args : test_defines,
                      dependencies : [gstreamer, gstcheck])
 
 aacdec = executable('acmaacdec',
                     aacdec_src,
+                    c_args : test_defines,
                     dependencies : [gstreamer, gstcheck])
 
 aacenc = executable('acmaacenc',
                     aacenc_src,
+                    c_args : test_defines,
                     dependencies : [gstreamer, gstcheck, gstapp],
                     include_directories : inc)
 
 h264enc = executable('acmh264enc',
                      h264enc_src,
+                     c_args : test_defines,
                      dependencies : [gstreamer, gstcheck, gstapp])
 
 jpegenc = executable('acmjpegenc',
                      jpegenc_src,
+                     c_args : test_defines,
                      dependencies : [gstreamer, gstcheck, gstapp],
                      include_directories : inc)
 
 fbdevsink = executable('acmfbdevsink',
                        fbdevsink_src,
+                       c_args : test_defines,
                        dependencies : [gstreamer, gstcheck])


### PR DESCRIPTION
tests/ に meson.build を追加し、meson でテストをビルドできるようにしました。

COMMIT: 72f9b64 については、この他に`data/` を meson のビルドディレクトリにコピーする、symbolic link を貼る。などの方法が考えられますが、[gst-plugins-base で使われている方法](https://cgit.freedesktop.org/gstreamer/gst-plugins-base/tree/tests/check/meson.build#n83)に合わせました。しかし、この Pull request のパッチでは Makefile を使うとテストはテストリソースを相対パスで参照し、Meson を使うと絶対パスで参照するようになります。 *どちらも合わせるべき* などのコメントを貰えるとうれしいです。